### PR TITLE
feat: scaffold Apify Actor structure for HRSCRAPER

### DIFF
--- a/.actor/actor.json
+++ b/.actor/actor.json
@@ -1,0 +1,9 @@
+{
+  "actorSpecification": 1,
+  "name": "hrscraper",
+  "title": "HRSCRAPER Actor",
+  "description": "Comprehensive scraper for HR-related datasets with enrichment and API output capabilities.",
+  "version": "0.0.1",
+  "buildTag": "latest",
+  "environmentVariables": []
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM apify/actor-node:20
+
+COPY package*.json ./
+RUN npm install --omit=dev
+
+COPY . ./
+
+CMD ["node", "src/main.js"]

--- a/README_ACTOR.md
+++ b/README_ACTOR.md
@@ -1,0 +1,14 @@
+# HRSCRAPER Actor
+
+This Actor is part of the HRSCRAPER project.
+
+## Run locally
+```bash
+npm install
+apify run
+```
+
+## Notes
+
+* This is a scaffold only; scraping logic will be added incrementally in later PRs.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "hrscraper",
+  "version": "0.0.1",
+  "type": "module",
+  "dependencies": {
+    "apify": "^3.0.0"
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,6 @@
+import { Actor } from "apify";
+
+await Actor.main(async () => {
+    console.log("🚀 HRSCRAPER Actor started successfully.");
+    await Actor.pushData({ status: "ok", message: "Initial Actor scaffold working." });
+});


### PR DESCRIPTION
## Summary
- add initial Apify Actor metadata and entry point under `.actor/actor.json` and `src/main.js`
- configure npm package manifest and Dockerfile for deploying the Actor
- document Actor usage in the new `README_ACTOR.md`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff11185048323ab7430d1ad3f8ea8